### PR TITLE
chore(workflows): bump gh-plumbing reusables to v1.1.19

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -20,6 +20,6 @@ on:
 
 jobs:
   automerge:
-    uses: nolte/gh-plumbing/.github/workflows/reuseable-automerge.yaml@v1.1.15
+    uses: nolte/gh-plumbing/.github/workflows/reusable-automerge.yaml@v1.1.19
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-static-tests.yaml
+++ b/.github/workflows/build-static-tests.yaml
@@ -12,14 +12,14 @@ permissions:
 
 jobs:
   static:
-    uses: nolte/gh-plumbing/.github/workflows/reuseable-pre-commit.yaml@v1.1.15
+    uses: nolte/gh-plumbing/.github/workflows/reusable-pre-commit.yaml@v1.1.19
   security:
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
-    uses: nolte/gh-plumbing/.github/workflows/reuseable-trivy.yaml@v1.1.15
+    uses: nolte/gh-plumbing/.github/workflows/reusable-trivy.yaml@v1.1.19
   chain-bench:
-    uses: nolte/gh-plumbing/.github/workflows/reuseable-chain-bench.yaml@v1.1.15
+    uses: nolte/gh-plumbing/.github/workflows/reusable-chain-bench.yaml@v1.1.19
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tf-lint.yaml
+++ b/.github/workflows/tf-lint.yaml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   lint:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-tf-lint.yaml@v1.1.15
+    uses: nolte/gh-plumbing/.github/workflows/reusable-tf-lint.yaml@v1.1.19
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Bumps every `nolte/gh-plumbing/.github/workflows/*@v1.1.15` pin to `@v1.1.19` and corrects the legacy `reuseable-*` filename typo to `reusable-*` (the file under v1.1.19 is published only at the corrected name).

## Changes

- Bump pins from `@v1.1.15` to `@v1.1.19` across 3 workflow files:
  - `.github/workflows/automerge.yaml` (filename `reuseable-` → `reusable-` on the `uses:` line)
  - `.github/workflows/build-static-tests.yaml` (3 pins; filename `reuseable-` → `reusable-` on all three `uses:` lines)
  - `.github/workflows/tf-lint.yaml` (already `reusable-tf-lint.yaml`, pin only)
- Caller `secrets:` blocks are already explicit (`secrets.token: ${{ secrets.GITHUB_TOKEN }}`), so no caller-side migration is needed.

## Linked issues

None

## Testing

- `gh api repos/nolte/gh-plumbing/contents/.github/workflows?ref=v1.1.19` confirms only `reusable-*` files exist at v1.1.19 (no `reuseable-*`).
- `git diff --stat` confirms only intended pin + filename changes.
- This PR uses native `gh pr merge --squash --auto` because `pascalgn/automerge-action` is broken on this repo until the new pin lands.

## Risk / rollout notes

Optional `app-id` + `secrets.app-private-key` (the portfolio-app cascade) are NOT added here — that adoption is a separate per-repo opt-in once the `PORTFOLIO_APP_ID` variable and `PORTFOLIO_APP_PRIVATE_KEY` secret are configured for this repo. Once merged, the repo's reusable workflow callers can again resolve, restoring the green CI baseline.
