### PR TITLE
chore(portfolio): mark repository portfolio: excluded

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,8 @@
+<!-- portfolio: excluded — personal home-lab Kubernetes cluster, infrastructure rather than a portfolio capability -->
+
+# k8s-home-lab
+
+This repository is intentionally **excluded** from the nolte portfolio
+capability inventory via the `portfolio: excluded` marker above, per
+`spec/portfolio/portfolio-management/` §Portfolio scope. It is therefore not
+expected to ship a `project/portfolio.yml` manifest.


### PR DESCRIPTION
Adds the `portfolio: excluded` marker to `CLAUDE.md` per `spec/portfolio/portfolio-management/` §Portfolio scope, resolving a missing-manifest finding from the 2026-06-02 portfolio audit.

Rationale: personal home-lab Kubernetes cluster, infrastructure rather than a portfolio capability